### PR TITLE
Redesign blog and stuff pages, add llms.txt for AI discoverability

### DIFF
--- a/_data/tags.yml
+++ b/_data/tags.yml
@@ -1,0 +1,36 @@
+aws:
+  label: AWS
+  emoji: "🛰️"
+bedrock:
+  label: Bedrock
+  emoji: "⛰️"
+langchain:
+  label: LangChain
+  emoji: "🦜"
+genai:
+  label: GenAI
+  emoji: "🤖"
+agents:
+  label: Agents
+  emoji: "🕹️"
+embeddings-rag:
+  label: Embeddings & RAG
+  emoji: "🧭"
+safety-critical-ai:
+  label: Safety-Critical AI
+  emoji: "🛡️"
+serverless:
+  label: Serverless
+  emoji: "λ"
+open-source:
+  label: Open Source
+  emoji: "🌱"
+talks-events:
+  label: Talks & Events
+  emoji: "🎤"
+machine-learning:
+  label: Machine Learning
+  emoji: "📈"
+security:
+  label: Security
+  emoji: "🔒"

--- a/_posts/2020-10-14-wbme-ml-workshop.md
+++ b/_posts/2020-10-14-wbme-ml-workshop.md
@@ -1,6 +1,7 @@
 ---
 title: WBME Workshop - Machine Learning for Medicine and Healthcare 👨‍⚕️
 layout: default
+tags: [machine-learning, talks-events]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2021-02-10-amazon-lookout-for-vision.md
+++ b/_posts/2021-02-10-amazon-lookout-for-vision.md
@@ -1,6 +1,7 @@
 ---
 title: Defect Detection with Amazon Lookout for Vision 🏭
 layout: default
+tags: [aws, machine-learning]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2021-02-27-qhack-recap.md
+++ b/_posts/2021-02-27-qhack-recap.md
@@ -1,6 +1,7 @@
 ---
 title: QHack Recap - PennyLane, Amazon Braket and Beyond 🚀
 layout: default
+tags: [talks-events, machine-learning]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2022-11-06-hf-on-trainium.md
+++ b/_posts/2022-11-06-hf-on-trainium.md
@@ -1,6 +1,7 @@
 ---
 title: HuggingFace 🤗 on Trainium
 layout: default
+tags: [aws, machine-learning]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2023-01-20-time-in-mle.md
+++ b/_posts/2023-01-20-time-in-mle.md
@@ -1,6 +1,7 @@
 ---
 title: Time in Machine Learning Engineering ⏳
 layout: default
+tags: [machine-learning]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2023-07-03-genai-tour.md
+++ b/_posts/2023-07-03-genai-tour.md
@@ -1,6 +1,7 @@
 ---
 title: A Tour of GenAI 🚀 - There and Back Again
 layout: default
+tags: [genai, talks-events]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2023-07-05-cost-optimization-on-aws.md
+++ b/_posts/2023-07-05-cost-optimization-on-aws.md
@@ -1,6 +1,7 @@
 ---
 title: Chatting with Support - Cost Optimization with AWS 💰
 layout: default
+tags: [aws]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2023-12-04-hf-tei-on-sagemaker.md
+++ b/_posts/2023-12-04-hf-tei-on-sagemaker.md
@@ -1,6 +1,7 @@
 ---
 title: Bringing 🤗 Text Embeddings Inference to Amazon SageMaker
 layout: default
+tags: [aws, embeddings-rag]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2023-12-20-bedrock-jcvd-langchain-template.md
+++ b/_posts/2023-12-20-bedrock-jcvd-langchain-template.md
@@ -1,6 +1,7 @@
 ---
 title: Bedrock JCVD 🕺🥋 on LangChain templates
 layout: default
+tags: [aws, bedrock, langchain]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-04-03-deploy-langchain-aws.md
+++ b/_posts/2024-04-03-deploy-langchain-aws.md
@@ -1,6 +1,7 @@
 ---
 title: Deploy LangChain 🦜🔗 applications on AWS with LangServe 🦜️🏓
 layout: default
+tags: [aws, langchain]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-04-05-yolambda.md
+++ b/_posts/2024-04-05-yolambda.md
@@ -1,6 +1,7 @@
 ---
 title: "#TGIFun🎈 YOLambda: Running Serverless YOLO Inference"
 layout: default
+tags: [aws, serverless, machine-learning]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-04-12-the-rise-of-llmos.md
+++ b/_posts/2024-04-12-the-rise-of-llmos.md
@@ -1,6 +1,7 @@
 ---
 title: "🧪 The Rise of the LLM OS: From AIOS to MemGPT and beyond"
 layout: default
+tags: [genai, agents]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-04-19-genai-apps-with-managed-services.md
+++ b/_posts/2024-04-19-genai-apps-with-managed-services.md
@@ -1,6 +1,7 @@
 ---
 title: "#TGIFun🎈 Building GenAI apps with managed AI services"
 layout: default
+tags: [aws, genai]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-04-23-mapping-embeddings.md
+++ b/_posts/2024-04-23-mapping-embeddings.md
@@ -1,6 +1,7 @@
 ---
 title: "Mapping embeddings: from meaning to vectors and back"
 layout: default
+tags: [embeddings-rag, genai]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-04-25-running-slms-on-lambda.md
+++ b/_posts/2024-04-25-running-slms-on-lambda.md
@@ -1,6 +1,7 @@
 ---
 title: "Running Small Language Models on AWS Lambda 🤏"
 layout: default
+tags: [aws, serverless, genai]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-05-03-fighting-hallucinations-with-llm-cascades.md
+++ b/_posts/2024-05-03-fighting-hallucinations-with-llm-cascades.md
@@ -1,6 +1,7 @@
 ---
 title: Fighting Hallucinations with LLM Cascades 🍄
 layout: default
+tags: [genai]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-05-06-bug-hunting-with-bedrock.md
+++ b/_posts/2024-05-06-bug-hunting-with-bedrock.md
@@ -1,6 +1,7 @@
 ---
 title: Bug hunting with Amazon Bedrock and SWE-Agent 👨‍💻
 layout: default
+tags: [aws, bedrock, agents]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-05-21-scrape-all-things.md
+++ b/_posts/2024-05-21-scrape-all-things.md
@@ -1,6 +1,7 @@
 ---
 title: "Scrape All Things: AI-powered scraping with ScrapeGraphAI 🕷️ and Amazon Bedrock ⛰️"
 layout: default
+tags: [aws, bedrock, agents]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-05-29-langchainjs-on-lambda.md
+++ b/_posts/2024-05-29-langchainjs-on-lambda.md
@@ -1,6 +1,7 @@
 ---
 title: Running LangChain.js Applications on AWS Lambda 
 layout: default
+tags: [aws, langchain, serverless]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-06-03-your-idea-is-my-command.md
+++ b/_posts/2024-06-03-your-idea-is-my-command.md
@@ -1,6 +1,7 @@
 ---
 title: "Your idea is my command: multi-agent collaboration for software development 💡🚀"
 layout: default
+tags: [agents, genai]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-06-25-build-pipelines-with-project-lakechain.md
+++ b/_posts/2024-06-25-build-pipelines-with-project-lakechain.md
@@ -1,6 +1,7 @@
 ---
 title: Build Document Processing Pipelines with Project Lakechain
 layout: default
+tags: [aws, open-source]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-07-02-leaving-no-language-behind.md
+++ b/_posts/2024-07-02-leaving-no-language-behind.md
@@ -1,6 +1,7 @@
 ---
 title: Leaving no language behind with Amazon SageMaker Serverless Inference 🌍💬
 layout: default
+tags: [aws, machine-learning]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-07-04-make-programs-not-prompts.md
+++ b/_posts/2024-07-04-make-programs-not-prompts.md
@@ -1,6 +1,7 @@
 ---
 title: "Make Programs, not Prompts: DSPy Pipelines with Llama 3 on Amazon SageMaker JumpStart"
 layout: default
+tags: [aws, genai]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-07-09-hacking-graphrag-with-bedrock.md
+++ b/_posts/2024-07-09-hacking-graphrag-with-bedrock.md
@@ -1,6 +1,7 @@
 ---
 title: Hacking GraphRAG with Amazon Bedrock 🌄
 layout: default
+tags: [aws, bedrock, embeddings-rag]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-10-23-vektordb.md
+++ b/_posts/2024-10-23-vektordb.md
@@ -1,6 +1,7 @@
 ---
 title: VektorDB 🏹 > Minimal Vector Database for Teaching
 layout: default
+tags: [embeddings-rag, open-source]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-10-26-serverless-llm-proxy.md
+++ b/_posts/2024-10-26-serverless-llm-proxy.md
@@ -1,6 +1,7 @@
 ---
 title: Serverless LLM Proxy ✨ /֎-Compatible/
 layout: default
+tags: [aws, serverless, open-source]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-10-29-cl-bedrock.md
+++ b/_posts/2024-10-29-cl-bedrock.md
@@ -1,6 +1,7 @@
 ---
 title: cl-bedrock 👽⛰️ > Amazon Bedrock meets Lisp
 layout: default
+tags: [aws, bedrock, open-source]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-10-31-llm-goblet.md
+++ b/_posts/2024-10-31-llm-goblet.md
@@ -1,6 +1,7 @@
 ---
 title: LLM Goblet 🍷 > LLM proxy application powered by AWS Chalice and LiteLLM
 layout: default
+tags: [aws, genai, open-source]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2024-11-12-command-ai-bedrock.md
+++ b/_posts/2024-11-12-command-ai-bedrock.md
@@ -1,6 +1,7 @@
 ---
 title: Command AI Assistant (Bedrock Edition) ⛰️👨‍💻
 layout: default
+tags: [aws, bedrock, agents]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2025-02-20-awesome-safety-critical-ai.md
+++ b/_posts/2025-02-20-awesome-safety-critical-ai.md
@@ -1,6 +1,7 @@
 ---
 title: Safety-Critical AI is now Awesome 🚀
 layout: default
+tags: [safety-critical-ai, open-source]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2025-04-09-ai-in-defense-podcast.md
+++ b/_posts/2025-04-09-ai-in-defense-podcast.md
@@ -1,6 +1,7 @@
 ---
 title: Critical Software @ Liga dos Inovadores 💡
 layout: default
+tags: [safety-critical-ai, talks-events]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2025-05-15-ai-red-teaming-csw.md
+++ b/_posts/2025-05-15-ai-red-teaming-csw.md
@@ -1,6 +1,7 @@
 ---
 title: AI Red Teaming @ Critical Software 🟥
 layout: default
+tags: [security, genai]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2025-05-30-ai2-team-building.md
+++ b/_posts/2025-05-30-ai2-team-building.md
@@ -1,6 +1,7 @@
 ---
 title: AI x Innovation @ AIHub 🧠
 layout: default
+tags: [talks-events]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2025-06-04-poolside-offsite.md
+++ b/_posts/2025-06-04-poolside-offsite.md
@@ -1,6 +1,7 @@
 ---
 title: poolside Offsite in Peniche 🥽
 layout: default
+tags: [talks-events]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2025-06-30-dependable-ai-in-airborne-systems.md
+++ b/_posts/2025-06-30-dependable-ai-in-airborne-systems.md
@@ -1,6 +1,7 @@
 ---
 title: Dependable AI in Airborne Systems ✈️
 layout: default
+tags: [safety-critical-ai, talks-events]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2025-08-10-oxfordml-2025-recap.md
+++ b/_posts/2025-08-10-oxfordml-2025-recap.md
@@ -1,6 +1,7 @@
 ---
 title: Oxford ML Summer School 2025 // Recap 🎓
 layout: default
+tags: [machine-learning, talks-events]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_posts/2026-03-19-dependable-critical-ai.md
+++ b/_posts/2026-03-19-dependable-critical-ai.md
@@ -1,6 +1,7 @@
 ---
 title: Build AI that matters 🌱 is now live!
 layout: default
+tags: [safety-critical-ai, talks-events]
 excerpt_separator: <!-- excerpt-end -->
 ---
 

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -129,3 +129,4 @@ hr {
 
 @import "typography";
 @import "tables";
+@import "components";

--- a/_sass/components.scss
+++ b/_sass/components.scss
@@ -1,0 +1,89 @@
+@import "vars";
+
+/*
+ * Tag filter (blog)
+ */
+
+.tag-filter {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    margin: 20px 0 30px 0;
+}
+.tag-chip {
+    font-family: "Inconsolata";
+    font-size: 14px;
+    background: none;
+    border: 1px solid rgba(0, 0, 0, 0.2);
+    border-radius: 999px;
+    padding: 5px 12px;
+    cursor: pointer;
+    color: #272727;
+    transition: 0.15s ease all;
+}
+.tag-chip:hover {
+    border-color: $accent;
+    color: $accent;
+}
+.tag-chip.is-active {
+    background: $accent;
+    border-color: $accent;
+    color: white;
+}
+
+.post-card {
+    border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+    padding-bottom: 15px;
+    margin-bottom: 25px;
+}
+.post-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 8px;
+    margin: -10px 0 10px 0;
+    color: rgba(0, 0, 0, 0.55);
+    font-size: 13px;
+}
+.tag-label {
+    background: rgba(0, 0, 0, 0.06);
+    border-radius: 999px;
+    padding: 2px 9px;
+}
+
+.hidden {
+    display: none;
+}
+
+/*
+ * Stuff hub
+ */
+
+.stuff-links {
+    display: grid;
+    gap: 16px;
+    margin: 20px 0;
+}
+.stuff-link-card {
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    border-radius: 10px;
+    padding: 14px 18px;
+    transition: 0.15s ease border-color;
+}
+.stuff-link-card:hover {
+    border-color: $accent;
+}
+.stuff-link-card h3 {
+    margin: 0 0 4px 0;
+}
+.stuff-link-card h3 a {
+    color: inherit;
+}
+.stuff-link-card h3 a:hover {
+    color: $accent;
+}
+.stuff-link-card p {
+    margin: 0;
+    color: rgba(0, 0, 0, 0.65);
+    font-size: 14px;
+}

--- a/blog.md
+++ b/blog.md
@@ -7,11 +7,69 @@ layout: default
 <img src="assets/images/boss.jpg" width="100%"/>
 </div>
 
+<p>{{ site.posts.size }} posts on AWS, GenAI, agents and building AI that actually holds up. Pick a topic below, or browse everything.</p>
+
+<div class="tag-filter">
+<button class="tag-chip is-active" data-tag="all">All ({{ site.posts.size }})</button>
+{% assign sorted_tags = site.tags | sort %}
+{% for tag in sorted_tags %}
+{% assign key = tag[0] %}
+{% assign meta = site.data.tags[key] %}
+<button class="tag-chip" data-tag="{{ key }}">{% if meta %}{{ meta.emoji }} {{ meta.label }}{% else %}{{ key }}{% endif %} ({{ tag[1].size }})</button>
+{% endfor %}
+</div>
+
+<div id="post-list">
 {% for post in site.posts %}
+<article class="post-card" data-tags="{{ post.tags | join: ' ' }}">
+
 ### [{{ post.title }}]({{ post.url }})
+
+<div class="post-meta">
+<time>{{ post.date | date: "%Y-%m-%d" }}</time>
+{% for t in post.tags %}
+{% assign meta = site.data.tags[t] %}
+<span class="tag-label">{% if meta %}{{ meta.emoji }} {{ meta.label }}{% else %}{{ t }}{% endif %}</span>
+{% endfor %}
+</div>
 
 {% assign excerptParts = post.excerpt | split: "<!-- excerpt-start -->" %}
 {{ excerptParts[1] }}
 
----
+</article>
 {% endfor %}
+</div>
+
+<p id="empty-state" class="hidden">Nothing tagged with that topic yet — try another one.</p>
+
+<script>
+(function () {
+  var chips = document.querySelectorAll(".tag-chip");
+  var cards = document.querySelectorAll(".post-card");
+  var empty = document.getElementById("empty-state");
+
+  function applyTag(tag) {
+    var chip = document.querySelector('.tag-chip[data-tag="' + tag + '"]') || chips[0];
+    chips.forEach(function (c) { c.classList.remove("is-active"); });
+    chip.classList.add("is-active");
+
+    var visible = 0;
+    cards.forEach(function (card) {
+      var tags = (card.getAttribute("data-tags") || "").split(" ");
+      var show = tag === "all" || tags.indexOf(tag) !== -1;
+      card.style.display = show ? "" : "none";
+      if (show) visible++;
+    });
+    empty.classList.toggle("hidden", visible !== 0);
+  }
+
+  chips.forEach(function (chip) {
+    chip.addEventListener("click", function () {
+      applyTag(chip.getAttribute("data-tag"));
+    });
+  });
+
+  var hashTag = window.location.hash.replace("#", "");
+  if (hashTag) applyTag(hashTag);
+})();
+</script>

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,31 @@
+---
+permalink: /llms.txt
+---
+# {{ site.title }}
+
+> {{ site.author }} leads AI at Critical Software, previously built ML at Siemens and worked with startups at AWS. This site collects writing and projects on AWS, GenAI, agents, and building AI that holds up under real-world pressure, especially in safety-critical and high-stakes domains.
+
+## Pages
+
+- [About]({{ site.url }}/about): background, current role, CV
+- [Blog]({{ site.url }}/blog): {{ site.posts.size }} posts, browsable by topic
+- [Stuff]({{ site.url }}/stuff): curated links on AI & learning, startups, and fun curiosities
+  - [AI & Learning]({{ site.url }}/stuff/ai-and-learning)
+  - [Startups]({{ site.url }}/stuff/startups)
+  - [Fun & Curiosities]({{ site.url }}/stuff/fun)
+
+## Topics
+{% assign sorted_tags = site.tags | sort %}
+{%- for tag in sorted_tags %}
+{%- assign key = tag[0] %}
+{%- assign meta = site.data.tags[key] %}
+- {% if meta %}{{ meta.label }}{% else %}{{ key }}{% endif %} ({{ tag[1].size }} posts): {{ site.url }}/blog#{{ key }}
+{%- endfor %}
+
+## Posts
+{% assign sorted_posts = site.posts | sort: 'date' | reverse %}
+{%- for post in sorted_posts %}
+{%- assign excerptParts = post.excerpt | split: "<!-- excerpt-start -->" %}
+{%- assign clean_excerpt = excerptParts[1] | strip_html | strip_newlines | strip %}
+- [{{ post.title | strip_html }}]({{ site.url }}{{ post.url }}) — {{ post.date | date: "%Y-%m-%d" }}, tags: {{ post.tags | join: ", " }}: {{ clean_excerpt }}
+{%- endfor %}

--- a/stuff.md
+++ b/stuff.md
@@ -7,102 +7,23 @@ layout: default
 <img src="assets/images/escher.png" width="100%"/>
 </div>
 
-## Useful Links
+A few things worth your time, sorted so you don't have to dig.
 
-For AI practitioners 🧠
+<div class="stuff-links">
 
-* Essential papers that shaped modern AI and ML — every practitioner should read these at least once:
-    - [A Few Useful Things to Know about Machine Learning](https://dl.acm.org/doi/10.1145/2347736.2347755) by Domingos
-    - [Machine Learning that Matters](https://arxiv.org/abs/1206.4656) by Wagstaff
-    - [Tidy Data](https://vita.had.co.nz/papers/tidy-data.html) by Wickham
-    - [Hidden Technical Debt](https://papers.nips.cc/paper_files/paper/2015/hash/86df7dcfd896fcaf2674f757a2463eba-Abstract.html) by Sculley et al.
-    - [The Unreasonable Effectiveness of Data](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/35179.pdf) by Halevy, Norvig, and Pereira
-* If you want to work on AI for high-stakes domains, check out [Awesome Safety-Critical AI](https://awesome.critical-ai.dev)
-* I can't edit them anymore, but some of my older articles are still available on [AWS Community](https://community.aws/@jgalego)
-
-<div align="center">
-<iframe width="70%" height="300px" src="https://dependable.critical-ai.dev">
-Your browser doesn't support iframes? Really?!
-</iframe>
+<div class="stuff-link-card">
+<h3><a href="/stuff/ai-and-learning">AI & Learning 🧠</a></h3>
+<p>Essential papers, my decks, and shortcuts for people in a hurry.</p>
 </div>
 
-<div align="center">
-<iframe width="70%" height="300px" src="https://critical-ai.dev/GenAI">
-Your browser doesn't support iframes? Really?!
-</iframe>
+<div class="stuff-link-card">
+<h3><a href="/stuff/startups">Startups 🐣</a></h3>
+<p>Reading list for founders — Y Combinator, Paul Graham, Zero to One.</p>
 </div>
 
-<div align="center">
-<iframe width="70%" height="300px" src="https://critical-ai.dev/MappingEmbeddings">
-Your browser doesn't support iframes? Really?!
-</iframe>
+<div class="stuff-link-card">
+<h3><a href="/stuff/fun">Fun & Curiosities 🎡</a></h3>
+<p>Nand2Tetris, xkcd, self-replicating code, and other rabbit holes.</p>
 </div>
 
-For startups 🐣
-
-* [Y Combinator Startup School](https://www.startupschool.org/) offers a *free* 8-week crash course in startup fundamentals — don't miss it
-* [Paul Graham's essays](http://www.paulgraham.com/articles.html) are absolute gems that cut through the entrepreneurship noise — start with [how to get startup ideas](http://www.paulgraham.com/startupideas.html) and [18 mistakes that kill startups](http://www.paulgraham.com/startupmistakes.html)
-* Peter Thiel's [Zero to One: Notes on Startups, or How to Build the Future](https://www.amazon.com/Zero-One-Notes-Startups-Future/dp/0804139296) is provocative and essential — you won't agree with everything (I don't!), but you won't stay indifferent
-* [Startup Stash](https://startupstash.com/) curates an extensive toolkit for startup founders and entrepreneurs
-
-<div align="center">
-<!-- Cartman's 4 point business plan -->
-<img src="assets/images/south_park_4point_plan.gif" width="25%"/>
-</div>
-
-For people in a hurry 🏃 💨
-
-* [Learn X in Y minutes](https://learnxinyminutes.com/) delivers a whirlwind tour of ([almost](https://github.com/adambard/learnxinyminutes-docs/issues)) every programming language — perfect for when you need to pick up a new language yesterday
-* [Icons](https://thenounproject.com/) and [emojis](https://emojidb.org/) for every occasion and mood
-* Too lazy to implement that classic algorithm? [The Algorithms](https://the-algorithms.com/) has you covered with GitHub's largest open-source algorithm library
-* [Hugging Face 🤗 Models](https://huggingface.co/models) lets you experiment with cutting-edge ML models online — completely *free*
-* Need an API? This [comprehensive list of publicly available APIs](https://github.com/public-apis/public-apis) is your new best friend
-* Stuck debugging? Invest in a [rubber duck](https://rubberduckdebugging.com/) — yes, the bathtub kind works best
-
-<div align="center">
-<!-- Ernie rubber duck debugging -->
-<img src="https://media2.giphy.com/media/CGMcKCEy4Dct2/giphy.gif" width="25%"/>
-</div>
-
-## (Supposedly) Fun Things
-
-* [Nand2Tetris](https://www.nand2tetris.org/) is a journey from NAND gates to Tetris — build a complete modern computer from first principles. It has inspired incredible projects like a [16-bit ALU in Minecraft](https://hackaday.com/2010/09/29/16-bit-alu-in-minecraft/) ⛏🧱
-* Charles Petzold's [Code: The Hidden Language of Computer Hardware and Software](https://www.codehiddenlanguage.com/) is an absolute masterpiece that takes you from flashlight morse code 🔦 to the *"worldwide hum of the internet"* 🌐
-* Erik Demaine's [lectures on algorithms and data structures](https://erikdemaine.org/classes/) will bend your mind in the best way — his talks on [models of computation](https://ocw.mit.edu/courses/6-006-introduction-to-algorithms-fall-2011/resources/lecture-2-models-of-computation-document-distance/) will forever change how you see Python scripts, while [temporal data structures](http://courses.csail.mit.edu/6.851/spring21/lectures/L01.html) comes with time travel analogies 🕓🚀 and movie references
-* Kevin Zurawel's [Game Development in 8 Bits or... Stupid NES Tricks](https://www.youtube.com/watch?v=TPbroUDHG0s) is a masterclass in thriving within creative constraints
-* [Choose Boring Technology](https://boringtechnology.club/) — or *"how to be old, for young people"*
-* Watch Terry Tao [formalize a proof](https://terrytao.wordpress.com/2023/11/18/formalizing-the-proof-of-pfr-in-lean4-using-blueprint-a-short-tour/) of a [Marton conjecture](https://terrytao.wordpress.com/2023/11/13/on-a-conjecture-of-marton/) in [Lean4](https://lean-lang.org/) — mathematics meets type theory
-* Peter Norvig's [pytudes](https://github.com/norvig/pytudes) are Python programs that are both delightful and instructive
-* Bartosz Ciechanowski's [interactive articles](https://ciechanow.ski/) transform mundane objects into fascinating explorations of physics and engineering
-* Evan Miller's [A/B testing tools](https://www.evanmiller.org/ab-testing/) — everything you need to design and analyze rigorous experiments
-* [MinutePhysics](https://www.youtube.com/c/minutephysics) explains complex physics in minutes using brilliant whiteboard animations — the [boat wakes](https://www.youtube.com/watch?v=95sQcSulRFM) video is pure joy
-* Everything by [3Blue1Brown](https://www.youtube.com/@3blue1brown) is visual mathematics at its finest... [here's how](https://www.youtube.com/watch?v=rbu7Zu5X1zI) he creates those mesmerizing animations with [Manim](https://github.com/3b1b/manim)
-* Love brown-paper math? [Numberphile](https://www.youtube.com/user/Numberphile) has you covered
-* [Please don't say just hello in chat](https://nohello.net/en/) — imagine calling someone, saying hello, then immediately putting them on hold 🤦‍♀️
-
-## (Actually) Fun Things
-
-* [xkcd](https://xkcd.com) — the webcomic where romance meets sarcasm, math meets language, and nerds feel understood
-* [SMBC](https://smbc-comics.com) — tackling science, philosophy, superheroes, religion, romance, parenting, and the meaning of life with equal parts wit and wisdom
-* [IP over Avian Carriers (RFC 1149)](https://datatracker.ietf.org/doc/html/rfc1149) — networking via carrier pigeons 🐦, featuring gems like *"because IP only guarantees best effort delivery, loss of a carrier can be tolerated"*
-
-## Meta Stuff
-
-* Love self-replicating code like `_='_=%r;print(_%%_)';print(_%_)`? You'll be obsessed with [Quine Relay](https://github.com/mame/quine-relay)
-    - Bonus: it's the most elegant way to crash [ChatGPT](https://openai.com/blog/chatgpt/) with an [infinite loop](https://www.linkedin.com/posts/jgalego_chatgpt-activity-7019613458753011712-Tlsi?utm_source=share&utm_medium=member_desktop) ♾️💥
-    
-<div align="center">
-<!-- ChatGPT on Quine Relay -->
-<img src="assets/images/chatgpt_on_quine_relay.jpg" width="75%"/>
-</div>
-
-* GitHub hosts an [awesome list](https://github.com/sindresorhus/awesome) of awesome lists — cue [Russell's paradox](https://plato.stanford.edu/entries/russell-paradox/)
-* Douglas Hofstadter's [Gödel, Escher, Bach](https://www.amazon.com/G%C3%B6del-Escher-Bach-Eternal-Golden/dp/0465026567) is the ultimate journey into self-reference and recursion, featuring Carroll-inspired dialogues and mind-bending insights
-* *The Atlantic* explores why [`meta` doesn't mean what you think it does](https://www.theatlantic.com/newsletters/archive/2022/06/meta-origin-irony/661191/) — a meta-commentary on meta itself
-* Matt Wood (former VP of AI @ AWS) built [PartyRock inside PartyRock](https://partyrock.aws/u/mza/pDK3iF1kb/PartyRocket-build-web-apps-with-gen-AI) — recursion meets [Amazon Bedrock](https://aws.amazon.com/bedrock/)
-* A warning sign warning you about warning signs — you've been warned! 🚨
-
-<div align="center">
-<!-- Meta Warning Sign -->
-<img src="https://64.media.tumblr.com/tumblr_lphraa31Hk1qkg7s3o1_400.jpg" width="30%"/>
 </div>

--- a/stuff/ai-and-learning.md
+++ b/stuff/ai-and-learning.md
@@ -1,0 +1,38 @@
+---
+title: AI & Learning 🧠
+layout: default
+---
+
+[← Back to Stuff](/stuff)
+
+## Essential papers
+
+Every practitioner should read these at least once:
+
+* [A Few Useful Things to Know about Machine Learning](https://dl.acm.org/doi/10.1145/2347736.2347755) by Domingos
+* [Machine Learning that Matters](https://arxiv.org/abs/1206.4656) by Wagstaff
+* [Tidy Data](https://vita.had.co.nz/papers/tidy-data.html) by Wickham
+* [Hidden Technical Debt](https://papers.nips.cc/paper_files/paper/2015/hash/86df7dcfd896fcaf2674f757a2463eba-Abstract.html) by Sculley et al.
+* [The Unreasonable Effectiveness of Data](https://static.googleusercontent.com/media/research.google.com/en//pubs/archive/35179.pdf) by Halevy, Norvig, and Pereira
+
+## My decks & projects
+
+* [Build AI that matters](https://dependable.critical-ai.dev) — building AI that works under pressure, not just in demos
+* [A Tour of GenAI](https://critical-ai.dev/GenAI) — where GenAI came from and where it's headed
+* [Mapping Embeddings](https://critical-ai.dev/MappingEmbeddings) — from meaning to vectors and back
+* If you want to work on AI for high-stakes domains, check out [Awesome Safety-Critical AI](https://awesome.critical-ai.dev)
+* I can't edit them anymore, but some of my older articles are still available on [AWS Community](https://community.aws/@jgalego)
+
+## For people in a hurry 🏃 💨
+
+* [Learn X in Y minutes](https://learnxinyminutes.com/) delivers a whirlwind tour of ([almost](https://github.com/adambard/learnxinyminutes-docs/issues)) every programming language — perfect for when you need to pick up a new language yesterday
+* [Icons](https://thenounproject.com/) and [emojis](https://emojidb.org/) for every occasion and mood
+* Too lazy to implement that classic algorithm? [The Algorithms](https://the-algorithms.com/) has you covered with GitHub's largest open-source algorithm library
+* [Hugging Face 🤗 Models](https://huggingface.co/models) lets you experiment with cutting-edge ML models online — completely *free*
+* Need an API? This [comprehensive list of publicly available APIs](https://github.com/public-apis/public-apis) is your new best friend
+* Stuck debugging? Invest in a [rubber duck](https://rubberduckdebugging.com/) — yes, the bathtub kind works best
+
+<div align="center">
+<!-- Ernie rubber duck debugging -->
+<img src="https://media2.giphy.com/media/CGMcKCEy4Dct2/giphy.gif" width="25%"/>
+</div>

--- a/stuff/fun.md
+++ b/stuff/fun.md
@@ -1,0 +1,49 @@
+---
+title: Fun & Curiosities 🎡
+layout: default
+---
+
+[← Back to Stuff](/stuff)
+
+## (Supposedly) Fun Things
+
+* [Nand2Tetris](https://www.nand2tetris.org/) is a journey from NAND gates to Tetris — build a complete modern computer from first principles. It has inspired incredible projects like a [16-bit ALU in Minecraft](https://hackaday.com/2010/09/29/16-bit-alu-in-minecraft/) ⛏🧱
+* Charles Petzold's [Code: The Hidden Language of Computer Hardware and Software](https://www.codehiddenlanguage.com/) is an absolute masterpiece that takes you from flashlight morse code 🔦 to the *"worldwide hum of the internet"* 🌐
+* Erik Demaine's [lectures on algorithms and data structures](https://erikdemaine.org/classes/) will bend your mind in the best way — his talks on [models of computation](https://ocw.mit.edu/courses/6-006-introduction-to-algorithms-fall-2011/resources/lecture-2-models-of-computation-document-distance/) will forever change how you see Python scripts, while [temporal data structures](http://courses.csail.mit.edu/6.851/spring21/lectures/L01.html) comes with time travel analogies 🕓🚀 and movie references
+* Kevin Zurawel's [Game Development in 8 Bits or... Stupid NES Tricks](https://www.youtube.com/watch?v=TPbroUDHG0s) is a masterclass in thriving within creative constraints
+* [Choose Boring Technology](https://boringtechnology.club/) — or *"how to be old, for young people"*
+* Watch Terry Tao [formalize a proof](https://terrytao.wordpress.com/2023/11/18/formalizing-the-proof-of-pfr-in-lean4-using-blueprint-a-short-tour/) of a [Marton conjecture](https://terrytao.wordpress.com/2023/11/13/on-a-conjecture-of-marton/) in [Lean4](https://lean-lang.org/) — mathematics meets type theory
+* Peter Norvig's [pytudes](https://github.com/norvig/pytudes) are Python programs that are both delightful and instructive
+* Bartosz Ciechanowski's [interactive articles](https://ciechanow.ski/) transform mundane objects into fascinating explorations of physics and engineering
+* Evan Miller's [A/B testing tools](https://www.evanmiller.org/ab-testing/) — everything you need to design and analyze rigorous experiments
+* [MinutePhysics](https://www.youtube.com/c/minutephysics) explains complex physics in minutes using brilliant whiteboard animations — the [boat wakes](https://www.youtube.com/watch?v=95sQcSulRFM) video is pure joy
+* Everything by [3Blue1Brown](https://www.youtube.com/@3blue1brown) is visual mathematics at its finest... [here's how](https://www.youtube.com/watch?v=rbu7Zu5X1zI) he creates those mesmerizing animations with [Manim](https://github.com/3b1b/manim)
+* Love brown-paper math? [Numberphile](https://www.youtube.com/user/Numberphile) has you covered
+* [Please don't say just hello in chat](https://nohello.net/en/) — imagine calling someone, saying hello, then immediately putting them on hold 🤦‍♀️
+
+## (Actually) Fun Things
+
+* [xkcd](https://xkcd.com) — the webcomic where romance meets sarcasm, math meets language, and nerds feel understood
+* [SMBC](https://smbc-comics.com) — tackling science, philosophy, superheroes, religion, romance, parenting, and the meaning of life with equal parts wit and wisdom
+* [IP over Avian Carriers (RFC 1149)](https://datatracker.ietf.org/doc/html/rfc1149) — networking via carrier pigeons 🐦, featuring gems like *"because IP only guarantees best effort delivery, loss of a carrier can be tolerated"*
+
+## Meta Stuff
+
+* Love self-replicating code like `_='_=%r;print(_%%_)';print(_%_)`? You'll be obsessed with [Quine Relay](https://github.com/mame/quine-relay)
+    - Bonus: it's the most elegant way to crash [ChatGPT](https://openai.com/blog/chatgpt/) with an [infinite loop](https://www.linkedin.com/posts/jgalego_chatgpt-activity-7019613458753011712-Tlsi?utm_source=share&utm_medium=member_desktop) ♾️💥
+
+<div align="center">
+<!-- ChatGPT on Quine Relay -->
+<img src="assets/images/chatgpt_on_quine_relay.jpg" width="75%"/>
+</div>
+
+* GitHub hosts an [awesome list](https://github.com/sindresorhus/awesome) of awesome lists — cue [Russell's paradox](https://plato.stanford.edu/entries/russell-paradox/)
+* Douglas Hofstadter's [Gödel, Escher, Bach](https://www.amazon.com/G%C3%B6del-Escher-Bach-Eternal-Golden/dp/0465026567) is the ultimate journey into self-reference and recursion, featuring Carroll-inspired dialogues and mind-bending insights
+* *The Atlantic* explores why [`meta` doesn't mean what you think it does](https://www.theatlantic.com/newsletters/archive/2022/06/meta-origin-irony/661191/) — a meta-commentary on meta itself
+* Matt Wood (former VP of AI @ AWS) built [PartyRock inside PartyRock](https://partyrock.aws/u/mza/pDK3iF1kb/PartyRocket-build-web-apps-with-gen-AI) — recursion meets [Amazon Bedrock](https://aws.amazon.com/bedrock/)
+* A warning sign warning you about warning signs — you've been warned! 🚨
+
+<div align="center">
+<!-- Meta Warning Sign -->
+<img src="https://64.media.tumblr.com/tumblr_lphraa31Hk1qkg7s3o1_400.jpg" width="30%"/>
+</div>

--- a/stuff/startups.md
+++ b/stuff/startups.md
@@ -1,0 +1,16 @@
+---
+title: Startups 🐣
+layout: default
+---
+
+[← Back to Stuff](/stuff)
+
+* [Y Combinator Startup School](https://www.startupschool.org/) offers a *free* 8-week crash course in startup fundamentals — don't miss it
+* [Paul Graham's essays](http://www.paulgraham.com/articles.html) are absolute gems that cut through the entrepreneurship noise — start with [how to get startup ideas](http://www.paulgraham.com/startupideas.html) and [18 mistakes that kill startups](http://www.paulgraham.com/startupmistakes.html)
+* Peter Thiel's [Zero to One: Notes on Startups, or How to Build the Future](https://www.amazon.com/Zero-One-Notes-Startups-Future/dp/0804139296) is provocative and essential — you won't agree with everything (I don't!), but you won't stay indifferent
+* [Startup Stash](https://startupstash.com/) curates an extensive toolkit for startup founders and entrepreneurs
+
+<div align="center">
+<!-- Cartman's 4 point business plan -->
+<img src="assets/images/south_park_4point_plan.gif" width="25%"/>
+</div>


### PR DESCRIPTION
Replaces the flat reverse-chron blog list with a topic-clustered,
client-side filterable view (tags added to all posts), breaks the
sprawling stuff.md link-dump into a slim hub plus three focused pages,
and adds an llms.txt so AI assistants can crawl and cite the site.